### PR TITLE
Fix critical bugs in state merging and self-updates (v0.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] 2025-08-05
+
+### Fixed
+
+- Fixed an issue with usage in combination with immer.In some cases merging state into non-extensible objects would fail.
+- Fixed self-update bug where clients would unnecessarily process their own state updates.
+
 ## [0.6.0] 2025-08-04
 
 ### Added
@@ -174,7 +181,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Partial state persistence with the partialize option
 - TokenHelper class for server-side token generation
 
-[Unreleased]: https://github.com/hpkv-io/zustand-multiplayer/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/hpkv-io/zustand-multiplayer/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/hpkv-io/zustand-multiplayer/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/hpkv-io/zustand-multiplayer/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/hpkv-io/zustand-multiplayer/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/hpkv-io/zustand-multiplayer/compare/v0.4.1...v0.4.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hpkv/zustand-multiplayer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hpkv/zustand-multiplayer",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@hpkv/websocket-client": "^1.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpkv/zustand-multiplayer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A multiplayer middleware for Zustand using HPKV",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/core/state-merger.ts
+++ b/src/core/state-merger.ts
@@ -112,6 +112,11 @@ export class StateMerger<TState> {
     let current = (state as Record<string, unknown>)[segments[0]] as Record<string, unknown>;
 
     for (let i = 1; i <= this.zFactor && i < segments.length; i++) {
+      // Check if object is extensible before adding properties
+      if (!Object.isExtensible(current)) {
+        // Return a copy of the non-extensible object to allow merging
+        current = { ...current };
+      }
       current[segments[i]] ??= {};
       current = current[segments[i]] as Record<string, unknown>;
     }

--- a/src/storage/hpkv-storage.ts
+++ b/src/storage/hpkv-storage.ts
@@ -290,6 +290,9 @@ export class HPKVStorage {
       try {
         if (typeof data.value === 'string') {
           const storedValue: StoredValue = JSON.parse(data.value) as StoredValue;
+          if (storedValue.clientId === this.getClientId()) {
+            return;
+          }
           actualValue = storedValue.value;
         }
       } catch {


### PR DESCRIPTION
 Summary

  - Fixed compatibility issue with Immer where state merging failed on non-extensible objects
  - Fixed performance issue where clients unnecessarily processed their own state updates
  - Bumped version to 0.6.1

  Details

  1. State Merger - Non-extensible Objects Fix
  When using zustand-multiplayer with Immer or other libraries that create non-extensible objects, the state merger would throw errors when attempting to add        
  properties. This fix detects non-extensible objects and creates a shallow copy before merging, ensuring compatibility with immutability libraries.

  2. HPKV Storage - Self-update Prevention
  Previously, clients would receive and process their own state updates from the HPKV server, causing unnecessary re-renders and potential performance issues.       
  This fix adds a client ID check to ignore self-originating updates, improving performance and preventing redundant state processing.

  Test Plan

  - Verified state merging works correctly with Immer-produced objects
  - Confirmed clients no longer process their own updates
  - Tested with multiple connected clients to ensure proper synchronization
  - Verified no regression in existing functionality

  These fixes improve reliability and performance, particularly for applications using immutability libraries or experiencing high-frequency state updates.